### PR TITLE
Fix scoped labels dropdown

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,6 +8,12 @@ module.exports = {
         'eslint:recommended',
         '@vue/eslint-config-typescript',
     ],
+    env: {
+        browser: true,
+    },
+    globals: {
+        chrome: 'readonly',
+    },
     parserOptions: {
         ecmaVersion: 'latest',
     },


### PR DESCRIPTION
## Summary
- allow Chrome globals during linting
- make scoped labels dropdown more robust for updated GitLab HTML structure
- handle scoped labels without `gl-label-text-scoped` span
- only show dropdown for scoped labels

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_6876a7acfb98832aaaf50acc294a07b2