### PR TITLE
Fix scoped labels teleport reattachment

### DIFF
--- a/src/components/ScopedLabelsDropdowns.vue
+++ b/src/components/ScopedLabelsDropdowns.vue
@@ -308,9 +308,15 @@
 
             const teleportElement = element.querySelector('span.gl-label-text-scoped')
                 || element.querySelector('span.gl-label-text');
-            if (teleportElement && !teleportElements.value[scopePrefix]) {
-                teleportElements.value[scopePrefix] = teleportElement as HTMLElement;
-                teleportElement.addEventListener('click', onClickLabelHandler);
+            if (teleportElement) {
+                const existingElement = teleportElements.value[scopePrefix];
+
+                if (existingElement !== teleportElement) {
+                    existingElement?.removeEventListener('click', onClickLabelHandler);
+
+                    teleportElements.value[scopePrefix] = teleportElement as HTMLElement;
+                    teleportElement.addEventListener('click', onClickLabelHandler);
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- ensure ScopedLabelsDropdowns reattaches teleport elements when reopened

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_b_68771a11fa14832a89a4d96ed541db9a